### PR TITLE
fix(provider): lift ramalama version cap

### DIFF
--- a/providers.d/remote/inference/ramalama.yaml
+++ b/providers.d/remote/inference/ramalama.yaml
@@ -1,6 +1,6 @@
 adapter:
   adapter_type: ramalama
-  pip_packages: ["ramalama==0.7.5"]
+  pip_packages: ["ramalama>=0.7.5"]
   config_class: llama_stack_provider_ramalama.config.RamalamaImplConfig
   module: llama_stack_provider_ramalama
 api_dependencies: []


### PR DESCRIPTION
allow for Llama Stack users to use newer versions of RamaLama beyond 0.7.5