### PR TITLE
ci: add additional pre commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,6 +12,8 @@ repos:
     -   id: check-added-large-files
         args: ['--maxkb=1000']
     -   id: end-of-file-fixer
+    -   id: check-toml
+    -   id: check-shebang-scripts-are-executable
 
 -   repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.9.4


### PR DESCRIPTION
now pre-commit will check both for toml issues and that scripts with shebang lines have proper permissions