### PR TITLE
feat: record ramalama connection success to logger

### DIFF
--- a/src/ramalama_stack/ramalama_adapter.py
+++ b/src/ramalama_stack/ramalama_adapter.py
@@ -63,6 +63,7 @@ class RamalamaInferenceAdapter(Inference, ModelsProtocolPrivate):
     async def initialize(self) -> None:
         logger.info(f"checking connectivity to Ramalama at `{self.url}`...")
         self.client = AsyncOpenAI(base_url=self.url, api_key="NO KEY")
+        logger.info(f"successfully connected to Ramalama at `{self.url}`...")
 
     async def shutdown(self) -> None:
         pass


### PR DESCRIPTION
currently we log when the adapter attempts connection but not the success of that connection