### PR TITLE
fix: mismatch between `ramalama.yaml` and `provider.py`

### DIFF
--- a/providers.d/remote/inference/ramalama.yaml
+++ b/providers.d/remote/inference/ramalama.yaml
@@ -1,6 +1,6 @@
 adapter:
   adapter_type: ramalama
-  pip_packages: ["ramalama>=0.7.5"]
+  pip_packages: ["ramalama>=0.7.5", "faiss-cpu"]
   config_class: ramalama_stack.config.RamalamaImplConfig
   module: ramalama_stack
 api_dependencies: []


### PR DESCRIPTION
`ramalama.yaml` is identical to `provider.py` except for a missing dependency