### PR TITLE
chore: bump project version to 0.1.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ramalama-stack"
-version = "0.1.0"
+version = "0.1.1"
 description = "Llama Stack Provider for Ramalama Inference"
 readme = "README.md"
 license = "Apache-2.0"

--- a/uv.lock
+++ b/uv.lock
@@ -1791,7 +1791,7 @@ wheels = [
 
 [[package]]
 name = "ramalama-stack"
-version = "0.1.0"
+version = "0.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary by Sourcery

Bump project version to 0.1.1.

Build:
- Update project version in pyproject.toml.
- Update uv.lock.