### PR TITLE
fix: minor bug with README badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # ramalama-stack
 
-[![PyPI version](https://img.shields.io/pypi/v/ramalama-stack.svg)](https://pypi.org/project/ramalama-stack/)
-[![License](https://img.shields.io/pypi/l/ramalama-stack.svg)](https://github.com/containers/ramalama-stack/blob/main/LICENSE)
+[![PyPI version](https://img.shields.io/pypi/v/ramalama_stack.svg)](https://pypi.org/project/ramalama-stack/)
+[![License](https://img.shields.io/pypi/l/ramalama_stack.svg)](https://github.com/containers/ramalama-stack/blob/main/LICENSE)
 ![Pre-Commit](https://github.com/containers/ramalama-stack/actions/workflows/pre-commit.yml/badge.svg?branch=main)
 ![Test External Providers](https://github.com/containers/ramalama-stack/actions/workflows/test-external-providers.yml/badge.svg?branch=main)
 ![PyPI](https://github.com/containers/ramalama-stack/actions/workflows/pypi.yml/badge.svg?branch=main)


### PR DESCRIPTION
## Summary by Sourcery

Documentation:
- Fix PyPI version and license badge URLs to use underscores instead of hyphens.