### PR TITLE
ci: allow 'test-external-providers' to run on demand

### DIFF
--- a/.github/workflows/test-external-providers.yml
+++ b/.github/workflows/test-external-providers.yml
@@ -1,6 +1,12 @@
 name: Test External Providers
 
 on:
+  workflow_dispatch:
+    inputs:
+      inference_model:
+        description: Model to download and inference via RamaLama
+        required: false
+        default: llama3.2:3b-instruct-fp16
   push:
     branches: [ main ]
   pull_request:
@@ -10,7 +16,7 @@ jobs:
   test-external-providers:
     runs-on: ubuntu-latest
     env:
-      INFERENCE_MODEL: llama3.2:3b-instruct-fp16
+      INFERENCE_MODEL: ${{ inputs.inference_model || 'llama3.2:3b-instruct-fp16' }}
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@0634a2670c59f64b4a01f0f96f84700a4088b9f0 # v2.12.0


### PR DESCRIPTION
also allow the usage of other models

'llama3.2:3b-instruct-fp16' will continue to be the default

## Summary by Sourcery

Enhance the external providers test workflow to support manual triggering with custom model selection

CI:
- Add workflow_dispatch event to allow manual triggering of external providers test
- Enable dynamic model selection for RamaLama inference tests