### PR TITLE
feat: use non-streaming tool calls for streaming tool calls

### DIFF
--- a/src/ramalama_stack/openai_compat.py
+++ b/src/ramalama_stack/openai_compat.py
@@ -129,6 +129,7 @@ async def convert_chat_completion_request(
             payload.update(
                 tool_choice=request.tool_config.tool_choice.value
             )  # we cannot include tool_choice w/o tools, server will complain
+        payload.update(stream=False)  # llama.cpp does not support streaming tool calls
 
     if request.logprobs:
         payload.update(logprobs=True)


### PR DESCRIPTION
Fixes #47

## Summary by Sourcery

Modify OpenAI compatibility layer to force non-streaming mode for tool calls due to llama.cpp limitations

New Features:
- Add explicit handling of streaming for tool calls in OpenAI-compatible API

Bug Fixes:
- Resolve issue with streaming tool calls in llama.cpp by forcing non-streaming mode

Enhancements:
- Improve tool call compatibility by overriding stream parameter