### PR TITLE
ci: add new nightly integration job

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           egress-policy: audit
 
-      - name: Checkout code
+      - name: Checkout containers/ramalama-stack
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Set up Python

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -41,12 +41,14 @@ jobs:
         with:
           egress-policy: audit
 
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Checkout containers/ramalama-stack
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           # for setuptools-scm
           fetch-depth: 0
 
-      - uses: hynek/build-and-inspect-python-package@b5076c307dc91924a82ad150cdd1533b444d3310 # v2.12.0
+      - name: Build and inspect python package
+        uses: hynek/build-and-inspect-python-package@b5076c307dc91924a82ad150cdd1533b444d3310 # v2.12.0
 
       - name: Run 'test-build.sh'
         run: $GITHUB_WORKSPACE/tests/test-build.sh

--- a/.github/workflows/test-lls-integration.yml
+++ b/.github/workflows/test-lls-integration.yml
@@ -1,4 +1,4 @@
-name: Test External Providers
+name: Test Llama Stack Integration
 
 on:
   workflow_dispatch:
@@ -7,13 +7,11 @@ on:
         description: Model to download and inference via RamaLama
         required: false
         default: llama3.2:3b-instruct-fp16
-  push:
-    branches: [ main ]
-  pull_request:
-    branches: [ main ]
+  schedule:
+    - cron: '0 11 * * *' # Runs at 11AM UTC every morning
 
 jobs:
-  test-external-providers:
+  test-lls-integration:
     runs-on: ubuntu-latest
     env:
       INFERENCE_MODEL: ${{ inputs.inference_model || 'llama3.2:3b-instruct-fp16' }}
@@ -25,6 +23,9 @@ jobs:
 
       - name: Checkout containers/ramalama-stack
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          # https://github.com/actions/checkout/issues/249
+          fetch-depth: 0
 
       - name: Install uv
         uses: astral-sh/setup-uv@6b9c6063abd6010835644d4c2e1bef4cf5cd0fca # v6.0.1
@@ -33,13 +34,13 @@ jobs:
 
       - name: Set Up Environment and Install Dependencies
         run: |
-          uv sync
-          uv pip install -e .
+          uv venv
 
-          # we need to hack the file moves typically done by the pip setup script
-          mkdir -p ~/.llama/distributions/ramalama/
-          cp -r src/ramalama_stack/providers.d/ ~/.llama/
-          cp src/ramalama_stack/ramalama-run.yaml ~/.llama/distributions/ramalama/ramalama-run.yaml
+          # install packaged version of ramalama-stack
+          uv pip install ramalama-stack
+
+          # update llama-stack version to main branch
+          uv pip install git+https://github.com/meta-llama/ramalama-stack.git@main
 
       - name: Run 'test-build.sh'
         run: $GITHUB_WORKSPACE/tests/test-build.sh

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![PyPI version](https://img.shields.io/pypi/v/ramalama_stack.svg)](https://pypi.org/project/ramalama-stack/)
 [![License](https://img.shields.io/pypi/l/ramalama_stack.svg)](https://github.com/containers/ramalama-stack/blob/main/LICENSE)
+![PyPI](https://github.com/containers/ramalama-stack/actions/workflows/pypi.yml/badge.svg?branch=main)
 ![Pre-Commit](https://github.com/containers/ramalama-stack/actions/workflows/pre-commit.yml/badge.svg?branch=main)
 ![Test External Providers](https://github.com/containers/ramalama-stack/actions/workflows/test-external-providers.yml/badge.svg?branch=main)
-![PyPI](https://github.com/containers/ramalama-stack/actions/workflows/pypi.yml/badge.svg?branch=main)
+![Test LLS Integration](https://github.com/containers/ramalama-stack/actions/workflows/test-lls-integration.yml/badge.svg?branch=main)


### PR DESCRIPTION
we want to test the currently-released ramalama-stack against the llama-stack main branch on a nightly basis

this will allow us to do any course-correcting needed to keep the provider working with llama-stack prior to them publishing a release

## Summary by Sourcery

Add a nightly integration test workflow to validate ramalama-stack compatibility with the latest llama-stack main branch

CI:
- Created a new GitHub Actions workflow to test ramalama-stack against llama-stack main branch nightly
- Added scheduled job running at 11AM UTC daily
- Implemented workflow to download and test with a default Llama3.2 model

Chores:
- Updated checkout step names in existing workflows for consistency