### PR TITLE
ci: standardize hack for file writing

### DIFF
--- a/.github/workflows/test-external-providers.yml
+++ b/.github/workflows/test-external-providers.yml
@@ -52,10 +52,11 @@ jobs:
           uv sync
           uv pip install -e .
 
-          # we need to hack the file moves typically done by the pip setup script
+          # temporary hack for file writing that should be done by the pip setup script
+          # https://github.com/containers/ramalama-stack/issues/53
           mkdir -p ~/.llama/distributions/ramalama/
-          cp -r src/ramalama_stack/providers.d/ ~/.llama/
-          cp src/ramalama_stack/ramalama-run.yaml ~/.llama/distributions/ramalama/ramalama-run.yaml
+          cp -r $GITHUB_WORKSPACE/src/ramalama_stack/providers.d/ ~/.llama/
+          cp $GITHUB_WORKSPACE/src/ramalama_stack/ramalama-run.yaml ~/.llama/distributions/ramalama/ramalama-run.yaml
 
       - name: Run 'test-build.sh'
         run: $GITHUB_WORKSPACE/tests/test-build.sh

--- a/.github/workflows/test-lls-integration.yml
+++ b/.github/workflows/test-lls-integration.yml
@@ -53,6 +53,12 @@ jobs:
           # update llama-stack version to main branch
           uv pip install git+https://github.com/meta-llama/llama-stack.git@main
 
+          # temporary hack for file writing that should be done by the pip setup script
+          # https://github.com/containers/ramalama-stack/issues/53
+          mkdir -p ~/.llama/distributions/ramalama/
+          cp -r $GITHUB_WORKSPACE/src/ramalama_stack/providers.d/ ~/.llama/
+          cp $GITHUB_WORKSPACE/src/ramalama_stack/ramalama-run.yaml ~/.llama/distributions/ramalama/ramalama-run.yaml
+
       - name: Run 'test-build.sh'
         run: $GITHUB_WORKSPACE/tests/test-build.sh
 


### PR DESCRIPTION
Workaround for https://github.com/containers/ramalama-stack/issues/53

## Summary by Sourcery

Standardize a temporary file writing hack across CI workflows to work around an issue with pip setup script

Bug Fixes:
- Fixed file placement issue in CI workflows by manually copying required files

CI:
- Added a consistent workaround for file copying in GitHub Actions workflows
- Updated file copy commands to use full $GITHUB_WORKSPACE path

Chores:
- Documented the temporary hack with a reference to the upstream issue