### PR TITLE
fix: adjust module

### DIFF
--- a/src/ramalama_stack/provider.py
+++ b/src/ramalama_stack/provider.py
@@ -13,6 +13,6 @@ def get_provider_spec() -> ProviderSpec:
             adapter_type="ramalama",
             pip_packages=["ramalama>=0.8.1", "faiss-cpu"],
             config_class="config.RamalamaImplConfig",
-            module="ramalama_adapter",
+            module="ramalama_stack",
         ),
     )


### PR DESCRIPTION
in get_provider_spec, if we want this to actually work we need the module to be ramalama_stack this method isn't currently used which is why we never caught this but it should be

## Summary by Sourcery

Bug Fixes:
- Corrected the module name from 'ramalama_adapter' to 'ramalama_stack' in the provider specification