### PR TITLE
feat: allow use of non-Llama models

### DIFF
--- a/.github/workflows/test-external-providers.yml
+++ b/.github/workflows/test-external-providers.yml
@@ -10,9 +10,17 @@ on:
   push:
     branches:
       - main
+    paths:
+      - 'src/ramalama_stack/**'
+      - 'tests/**'
+      - '.github/workflows/test-external-providers.yml'
   pull_request:
     branches:
       - main
+    paths:
+      - 'src/ramalama_stack/**'
+      - 'tests/**'
+      - '.github/workflows/test-external-providers.yml'
 
 env:
   LC_ALL: en_US.UTF-8
@@ -28,13 +36,21 @@ jobs:
   test-external-providers:
     name: test-external-providers
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        inference_model:
+          - 'llama3.2:3b-instruct-fp16'
+          - 'granite3.2:2b'
     env:
-      INFERENCE_MODEL: ${{ inputs.inference_model || 'llama3.2:3b-instruct-fp16' }}
+      INFERENCE_MODEL: ${{ inputs.inference_model || matrix.inference_model }}
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@0634a2670c59f64b4a01f0f96f84700a4088b9f0 # v2.12.0
         with:
           egress-policy: audit
+
+      - name: Set INFERENCE_MODEL_NO_COLON for logging artifacts
+        run: echo "INFERENCE_MODEL_NO_COLON=$(echo "$INFERENCE_MODEL" | tr ':' '_')" >> $GITHUB_ENV
 
       - name: Checkout containers/ramalama-stack
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -79,7 +95,7 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: always()
         with:
-          name: logs-test-external-providers
+          name: logs-test-external-providers-${{ env.INFERENCE_MODEL_NO_COLON }}
           retention-days: 5
           path: |
             **/*.log

--- a/src/ramalama_stack/ramalama_adapter.py
+++ b/src/ramalama_stack/ramalama_adapter.py
@@ -191,7 +191,6 @@ class RamalamaInferenceAdapter(Inference, ModelsProtocolPrivate):
         )
 
     async def register_model(self, model: Model) -> Model:
-        model = await self.register_helper.register_model(model)
         res = await self.client.models.list()
         available_models = [m.id async for m in res]
         # Ramalama handles paths on MacOS and Linux differently

--- a/tests/test-external-providers.sh
+++ b/tests/test-external-providers.sh
@@ -11,6 +11,8 @@ main() {
 }
 
 TEST_UTILS=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
+# shellcheck disable=SC2153,SC2034
+INFERENCE_MODEL_NO_COLON=$(echo "$INFERENCE_MODEL" | tr ':' '_')
 # shellcheck disable=SC1091
 source "$TEST_UTILS/utils.sh"
 main "$@"


### PR DESCRIPTION
Fixes #73

## Summary by Sourcery

Allow use of non-Llama models by extending the CI test matrix with granite support and cleaning up redundant registration logic in the adapter

New Features:
- Add granite3.2:2b non-Llama model to the external providers test matrix

Bug Fixes:
- Remove redundant model registration call in the adapter to prevent double-registration

CI:
- Restrict external-providers workflow to relevant paths
- Introduce matrix strategy for CI inference models
- Switch INFERENCE_MODEL env var to use matrix values