### PR TITLE
chore: update README for 0.2.2 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ This will install Llama Stack and RamaLama as well if they are not installed alr
 > [!WARNING]
 > The following workaround is currently needed to run this provider - see https://github.com/containers/ramalama-stack/issues/53 for more details
 > ```bash
-> curl --create-dirs --output ~/.llama/providers.d/remote/inference/ramalama.yaml https://raw.githubusercontent.com/containers/ramalama-stack/refs/tags/v0.2.1/src/ramalama_stack/providers.d/remote/inference/ramalama.yaml
-> curl --create-dirs --output ~/.llama/distributions/ramalama/ramalama-run.yaml https://raw.githubusercontent.com/containers/ramalama-stack/refs/tags/v0.2.1/src/ramalama_stack/ramalama-run.yaml
+> curl --create-dirs --output ~/.llama/providers.d/remote/inference/ramalama.yaml https://raw.githubusercontent.com/containers/ramalama-stack/refs/tags/v0.2.2/src/ramalama_stack/providers.d/remote/inference/ramalama.yaml
+> curl --create-dirs --output ~/.llama/distributions/ramalama/ramalama-run.yaml https://raw.githubusercontent.com/containers/ramalama-stack/refs/tags/v0.2.2/src/ramalama_stack/ramalama-run.yaml
 > ```
 
 1. First you will need a RamaLama server running - see [the RamaLama project](https://github.com/containers/ramalama) docs for more information.


### PR DESCRIPTION
## Summary by Sourcery

Documentation:
- Bump curl commands in README from v0.2.1 to v0.2.2 for the RamaLama provider and distribution URLs