### PR TITLE
fix: switched flag to enable streaming for tool calling

### DIFF
--- a/src/ramalama_stack/ramalama_adapter.py
+++ b/src/ramalama_stack/ramalama_adapter.py
@@ -134,7 +134,7 @@ class RamalamaInferenceAdapter(Inference, ModelsProtocolPrivate):
         s = await self.client.chat.completions.create(**request)
         if stream:
             return convert_openai_chat_completion_stream(
-                s, enable_incremental_tool_calls=False
+                s, enable_incremental_tool_calls=True
             )
         else:
             # we pass n=1 to get only one completion


### PR DESCRIPTION
checkout https://github.com/bmahabirbu/ramalama-stack/tree/rag to test the new tool calling feature with test-tools-agent.py. It creates an agent that uses rag depending on the query.

Thanks to @bbrowning from https://github.com/containers/ramalama-stack/issues/47